### PR TITLE
Add Drawable as start or end offset

### DIFF
--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
@@ -1,6 +1,8 @@
 package com.dgreenhalgh.android.simpleitemdecoration.linear;
 
+import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -16,6 +18,8 @@ import android.view.View;
 public class EndOffsetItemDecoration extends RecyclerView.ItemDecoration {
 
     private int mOffsetPx;
+    private Drawable mOffsetDrawable;
+    private int mOrientation;
 
     /**
      * Sole constructor. Takes in the size of the offset to be added to the end
@@ -26,6 +30,17 @@ public class EndOffsetItemDecoration extends RecyclerView.ItemDecoration {
      */
     public EndOffsetItemDecoration(int offsetPx) {
         mOffsetPx = offsetPx;
+    }
+
+    /**
+     * Constructor that takes in a {@link Drawable} to be drawn at the end of
+     * the RecyclerView.
+     *
+     * @param offsetDrawable The {@code Drawable} to be added to the end of the
+     *                       RecyclerView
+     */
+    public EndOffsetItemDecoration(Drawable offsetDrawable) {
+        mOffsetDrawable = offsetDrawable;
     }
 
     /**
@@ -42,13 +57,71 @@ public class EndOffsetItemDecoration extends RecyclerView.ItemDecoration {
         super.getItemOffsets(outRect, view, parent, state);
 
         int itemCount = state.getItemCount();
-        if (parent.getChildAdapterPosition(view) == itemCount - 1) {
-            int orientation = ((LinearLayoutManager) parent.getLayoutManager()).getOrientation();
-            if (orientation == LinearLayoutManager.HORIZONTAL) {
+        if (parent.getChildAdapterPosition(view) != itemCount - 1) {
+            return;
+        }
+
+        mOrientation = ((LinearLayoutManager) parent.getLayoutManager()).getOrientation();
+        if (mOrientation == LinearLayoutManager.HORIZONTAL) {
+            if (mOffsetPx > 0) {
                 outRect.right = mOffsetPx;
-            } else {
+            } else if (mOffsetDrawable != null) {
+                outRect.right = mOffsetDrawable.getIntrinsicWidth();
+            }
+        } else if (mOrientation == LinearLayoutManager.VERTICAL) {
+            if (mOffsetPx > 0) {
                 outRect.bottom = mOffsetPx;
+            } else if (mOffsetDrawable != null) {
+                outRect.bottom = mOffsetDrawable.getIntrinsicHeight();
             }
         }
+    }
+
+    /**
+     * Draws horizontal or vertical offset onto the end of the parent
+     * RecyclerView.
+     *
+     * @param c The {@link Canvas} onto which an offset will be drawn
+     * @param parent The RecyclerView onto which an offset is being added
+     * @param state The current RecyclerView.State of the RecyclerView
+     */
+    @Override
+    public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        super.onDraw(c, parent, state);
+        if (mOffsetDrawable == null) {
+            return;
+        }
+
+        if (mOrientation == LinearLayoutManager.HORIZONTAL) {
+            drawOffsetHorizontal(c, parent);
+        } else if (mOrientation == LinearLayoutManager.VERTICAL) {
+            drawOffsetVertical(c, parent);
+        }
+    }
+
+    private void drawOffsetHorizontal(Canvas canvas, RecyclerView parent) {
+        int parentTop = parent.getPaddingTop();
+        int parentBottom = parent.getHeight() - parent.getPaddingBottom();
+
+        View lastChild = parent.getChildAt(parent.getChildCount() - 1);
+        RecyclerView.LayoutParams lastChildLayoutParams = (RecyclerView.LayoutParams) lastChild.getLayoutParams();
+        int offsetDrawableLeft = lastChild.getRight() + lastChildLayoutParams.rightMargin;
+        int offsetDrawableRight = offsetDrawableLeft + mOffsetDrawable.getIntrinsicWidth();
+
+        mOffsetDrawable.setBounds(offsetDrawableLeft, parentTop, offsetDrawableRight, parentBottom);
+        mOffsetDrawable.draw(canvas);
+    }
+
+    private void drawOffsetVertical(Canvas canvas, RecyclerView parent) {
+        int parentLeft = parent.getPaddingLeft();
+        int parentRight = parent.getWidth() - parent.getPaddingRight();
+
+        View lastChild = parent.getChildAt(parent.getChildCount() - 1);
+        RecyclerView.LayoutParams lastChildLayoutParams = (RecyclerView.LayoutParams) lastChild.getLayoutParams();
+        int offsetDrawableTop = lastChild.getBottom() + lastChildLayoutParams.bottomMargin;
+        int offsetDrawableBottom = offsetDrawableTop + mOffsetDrawable.getIntrinsicHeight();
+
+        mOffsetDrawable.setBounds(parentLeft, offsetDrawableTop, parentRight, offsetDrawableBottom);
+        mOffsetDrawable.draw(canvas);
     }
 }

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
@@ -22,7 +22,7 @@ public class EndOffsetItemDecoration extends RecyclerView.ItemDecoration {
     private int mOrientation;
 
     /**
-     * Sole constructor. Takes in the size of the offset to be added to the end
+     * Constructor that takes in the size of the offset to be added to the end
      * of the RecyclerView.
      *
      * @param offsetPx The size of the offset to be added to the end of the

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
@@ -37,7 +37,7 @@ public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
      * the RecyclerView.
      *
      * @param offsetDrawable The {@code Drawable} to be added to the start of
-     *                       the RecyclerView.
+     *                       the RecyclerView
      */
     public StartOffsetItemDecoration(Drawable offsetDrawable) {
         mOffsetDrawable = offsetDrawable;
@@ -76,7 +76,8 @@ public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     /**
-     * Draws horizontal or vertical offset onto the parent RecyclerView.
+     * Draws horizontal or vertical offset onto the start of the parent
+     * RecyclerView.
      *
      * @param c The {@link Canvas} onto which an offset will be drawn
      * @param parent The RecyclerView onto which an offset is being added

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
@@ -1,6 +1,8 @@
 package com.dgreenhalgh.android.simpleitemdecoration.linear;
 
+import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -16,9 +18,11 @@ import android.view.View;
 public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
 
     private int mOffsetPx;
+    private Drawable mOffsetDrawable;
+    private int mOrientation;
 
     /**
-     * Sole constructor. Takes in the size of the offset to be added to the
+     * Constructor that takes in the size of the offset to be added to the
      * start of the RecyclerView.
      *
      * @param offsetPx The size of the offset to be added to the start of the
@@ -26,6 +30,17 @@ public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
      */
     public StartOffsetItemDecoration(int offsetPx) {
         mOffsetPx = offsetPx;
+    }
+
+    /**
+     * Constructor that takes in a {@link Drawable} to be drawn at the start of
+     * the RecyclerView.
+     *
+     * @param offsetDrawable The {@code Drawable} to be added to the start of
+     *                       the RecyclerView.
+     */
+    public StartOffsetItemDecoration(Drawable offsetDrawable) {
+        mOffsetDrawable = offsetDrawable;
     }
 
     /**
@@ -40,14 +55,65 @@ public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
     @Override
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
         super.getItemOffsets(outRect, view, parent, state);
+        if (parent.getChildAdapterPosition(view) > 0) {
+            return;
+        }
 
-        if (parent.getChildAdapterPosition(view) < 1) {
-            int orientation = ((LinearLayoutManager) parent.getLayoutManager()).getOrientation();
-            if (orientation == LinearLayoutManager.HORIZONTAL) {
+        mOrientation = ((LinearLayoutManager) parent.getLayoutManager()).getOrientation();
+        if (mOrientation == LinearLayoutManager.HORIZONTAL) {
+            if (mOffsetPx > 0) {
                 outRect.left = mOffsetPx;
-            } else if (orientation == LinearLayoutManager.VERTICAL) {
+            } else if (mOffsetDrawable != null) {
+                outRect.left = mOffsetDrawable.getIntrinsicWidth();
+            }
+        } else if (mOrientation == LinearLayoutManager.VERTICAL) {
+            if (mOffsetPx > 0) {
                 outRect.top = mOffsetPx;
+            } else if (mOffsetDrawable != null) {
+                outRect.top = mOffsetDrawable.getIntrinsicHeight();
             }
         }
+    }
+
+    /**
+     * Draws horizontal or vertical offset onto the parent RecyclerView.
+     *
+     * @param c The {@link Canvas} onto which an offset will be drawn
+     * @param parent The RecyclerView onto which an offset is being added
+     * @param state The current RecyclerView.State of the RecyclerView
+     */
+    @Override
+    public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        super.onDraw(c, parent, state);
+        if (mOffsetDrawable == null) {
+            return;
+        }
+
+        if (mOrientation == LinearLayoutManager.HORIZONTAL) {
+            drawOffsetHorizontal(c, parent);
+        } else if (mOrientation == LinearLayoutManager.VERTICAL) {
+            drawOffsetVertical(c, parent);
+        }
+    }
+
+
+    private void drawOffsetHorizontal(Canvas canvas, RecyclerView parent) {
+        int parentTop = parent.getPaddingTop();
+        int parentBottom = parent.getHeight() - parent.getPaddingBottom();
+        int parentLeft = parent.getPaddingLeft();
+        int offsetDrawableRight = parentLeft + mOffsetDrawable.getIntrinsicWidth();
+
+        mOffsetDrawable.setBounds(parentLeft, parentTop, offsetDrawableRight, parentBottom);
+        mOffsetDrawable.draw(canvas);
+    }
+
+    private void drawOffsetVertical(Canvas canvas, RecyclerView parent) {
+        int parentLeft = parent.getPaddingLeft();
+        int parentRight = parent.getWidth() - parent.getPaddingRight();
+        int parentTop = parent.getPaddingTop();
+        int offsetDrawableBottom = parentTop + mOffsetDrawable.getIntrinsicHeight();
+
+        mOffsetDrawable.setBounds(parentLeft, parentTop, parentRight, offsetDrawableBottom);
+        mOffsetDrawable.draw(canvas);
     }
 }


### PR DESCRIPTION
Previously, `StartOffsetItemDecoration` and `EndOffsetItemDecoration` only could offset the start or end of a `RecyclerView` by a number of pixels.

I've added the ability to pass in a `Drawable` to be drawn as an offset instead. This PR only adds support for `StartOffsetItemDecoration` and `EndOffsetItemDecoration`, as there is a change I'd like to make to the implementation of our `GridLayoutManager`-based solutions first.