### PR TITLE
Grid divider bounds refactor

### DIFF
--- a/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/GridLayoutManagerSampleActivity.java
+++ b/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/GridLayoutManagerSampleActivity.java
@@ -28,11 +28,15 @@ public class GridLayoutManagerSampleActivity extends ActionBarActivity {
     private RecyclerView mRecyclerView;
     private RecyclerView.ItemDecoration mDividerItemDecoration;
     private RecyclerView.ItemDecoration mStartOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mStartDrawableOffsetItemDecoration;
     private RecyclerView.ItemDecoration mEndOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mEndDrawableOffsetItemDecoration;
 
     private boolean mDividersVisible;
     private boolean mStartOffsetVisible;
+    private boolean mStartDrawableOffsetVisible;
     private boolean mEndOffsetVisible;
+    private boolean mEndDrawableOffsetVisible;
 
     public static Intent newIntent(Context context) {
         return new Intent(context, GridLayoutManagerSampleActivity.class);
@@ -63,8 +67,12 @@ public class GridLayoutManagerSampleActivity extends ActionBarActivity {
         int startOffsetPx = resources.getDimensionPixelOffset(R.dimen.start_offset);
         mStartOffsetItemDecoration = new GridTopOffsetItemDecoration(startOffsetPx, NUM_COLUMNS);
 
+        mStartDrawableOffsetItemDecoration = new GridTopOffsetItemDecoration(dividerDrawable, NUM_COLUMNS);
+
         int endOffsetPx = resources.getDimensionPixelOffset(R.dimen.end_offset);
         mEndOffsetItemDecoration = new GridBottomOffsetItemDecoration(endOffsetPx, NUM_COLUMNS);
+
+        mEndDrawableOffsetItemDecoration = new GridBottomOffsetItemDecoration(dividerDrawable, NUM_COLUMNS);
     }
 
     private void toggleDividerVisibility() {
@@ -87,6 +95,16 @@ public class GridLayoutManagerSampleActivity extends ActionBarActivity {
         }
     }
 
+    private void toggleStartDrawableOffsetVisibility() {
+        if (mStartDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = true;
+        }
+    }
+
     private void toggleEndOffsetVisibility() {
         if (mEndOffsetVisible) {
             mRecyclerView.removeItemDecoration(mEndOffsetItemDecoration);
@@ -94,6 +112,16 @@ public class GridLayoutManagerSampleActivity extends ActionBarActivity {
         } else {
             mRecyclerView.addItemDecoration(mEndOffsetItemDecoration);
             mEndOffsetVisible = true;
+        }
+    }
+
+    private void toggleEndDrawableOffsetVisibility() {
+        if (mEndDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = true;
         }
     }
 
@@ -109,8 +137,18 @@ public class GridLayoutManagerSampleActivity extends ActionBarActivity {
         }
 
         @Override
+        public void onStartDrawableOffsetVisibilityChange() {
+            toggleStartDrawableOffsetVisibility();
+        }
+
+        @Override
         public void onEndOffsetVisibilityChange() {
             toggleEndOffsetVisibility();
+        }
+
+        @Override
+        public void onEndDrawableOffsetVisibilityChange() {
+            toggleEndDrawableOffsetVisibility();
         }
     };
 }

--- a/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/HorizontalLinearLayoutManagerSampleActivity.java
+++ b/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/HorizontalLinearLayoutManagerSampleActivity.java
@@ -26,11 +26,15 @@ public class HorizontalLinearLayoutManagerSampleActivity extends ActionBarActivi
     private RecyclerView mRecyclerView;
     private RecyclerView.ItemDecoration mDividerItemDecoration;
     private RecyclerView.ItemDecoration mStartOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mStartDrawableOffsetItemDecoration;
     private RecyclerView.ItemDecoration mEndOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mEndDrawableOffsetItemDecoration;
 
     private boolean mDividersVisible;
     private boolean mStartOffsetVisible;
+    private boolean mStartDrawableOffsetVisible;
     private boolean mEndOffsetVisible;
+    private boolean mEndDrawableOffsetVisible;
 
     public static Intent newIntent(Context context) {
         return new Intent(context, HorizontalLinearLayoutManagerSampleActivity.class);
@@ -61,8 +65,12 @@ public class HorizontalLinearLayoutManagerSampleActivity extends ActionBarActivi
         int startOffsetPx = resources.getDimensionPixelOffset(R.dimen.start_offset);
         mStartOffsetItemDecoration = new StartOffsetItemDecoration(startOffsetPx);
 
+        mStartDrawableOffsetItemDecoration = new StartOffsetItemDecoration(dividerDrawable);
+
         int endOffsetPx = resources.getDimensionPixelOffset(R.dimen.end_offset);
         mEndOffsetItemDecoration = new EndOffsetItemDecoration(endOffsetPx);
+
+        mEndDrawableOffsetItemDecoration = new EndOffsetItemDecoration(dividerDrawable);
     }
 
     private void toggleDividerVisibility() {
@@ -85,6 +93,16 @@ public class HorizontalLinearLayoutManagerSampleActivity extends ActionBarActivi
         }
     }
 
+    private void toggleStartDrawableOffsetVisibility() {
+        if (mStartDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = true;
+        }
+    }
+
     private void toggleEndOffsetVisibility() {
         if (mEndOffsetVisible) {
             mRecyclerView.removeItemDecoration(mEndOffsetItemDecoration);
@@ -92,6 +110,16 @@ public class HorizontalLinearLayoutManagerSampleActivity extends ActionBarActivi
         } else {
             mRecyclerView.addItemDecoration(mEndOffsetItemDecoration);
             mEndOffsetVisible = true;
+        }
+    }
+
+    private void toggleEndDrawableOffsetVisibility() {
+        if (mEndDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = true;
         }
     }
 
@@ -107,8 +135,18 @@ public class HorizontalLinearLayoutManagerSampleActivity extends ActionBarActivi
         }
 
         @Override
+        public void onStartDrawableOffsetVisibilityChange() {
+            toggleStartDrawableOffsetVisibility();
+        }
+
+        @Override
         public void onEndOffsetVisibilityChange() {
             toggleEndOffsetVisibility();
+        }
+
+        @Override
+        public void onEndDrawableOffsetVisibilityChange() {
+            toggleEndDrawableOffsetVisibility();
         }
     };
 }

--- a/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/VerticalLinearLayoutManagerSampleActivity.java
+++ b/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/controller/VerticalLinearLayoutManagerSampleActivity.java
@@ -26,11 +26,15 @@ public class VerticalLinearLayoutManagerSampleActivity extends ActionBarActivity
     private RecyclerView mRecyclerView;
     private RecyclerView.ItemDecoration mDividerItemDecoration;
     private RecyclerView.ItemDecoration mStartOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mStartDrawableOffsetItemDecoration;
     private RecyclerView.ItemDecoration mEndOffsetItemDecoration;
+    private RecyclerView.ItemDecoration mEndDrawableOffsetItemDecoration;
 
     private boolean mDividersVisible;
     private boolean mStartOffsetVisible;
+    private boolean mStartDrawableOffsetVisible;
     private boolean mEndOffsetVisible;
+    private boolean mEndDrawableOffsetVisible;
 
     public static Intent newIntent(Context context) {
         return new Intent(context, VerticalLinearLayoutManagerSampleActivity.class);
@@ -61,8 +65,12 @@ public class VerticalLinearLayoutManagerSampleActivity extends ActionBarActivity
         int startOffsetPx = resources.getDimensionPixelOffset(R.dimen.start_offset);
         mStartOffsetItemDecoration = new StartOffsetItemDecoration(startOffsetPx);
 
+        mStartDrawableOffsetItemDecoration = new StartOffsetItemDecoration(dividerDrawable);
+
         int endOffsetPx = resources.getDimensionPixelOffset(R.dimen.end_offset);
         mEndOffsetItemDecoration = new EndOffsetItemDecoration(endOffsetPx);
+
+        mEndDrawableOffsetItemDecoration = new EndOffsetItemDecoration(dividerDrawable);
     }
 
     private void toggleDividerVisibility() {
@@ -85,6 +93,16 @@ public class VerticalLinearLayoutManagerSampleActivity extends ActionBarActivity
         }
     }
 
+    private void toggleStartDrawableOffsetVisibility() {
+        if (mStartDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mStartDrawableOffsetItemDecoration);
+            mStartDrawableOffsetVisible = true;
+        }
+    }
+
     private void toggleEndOffsetVisibility() {
         if (mEndOffsetVisible) {
             mRecyclerView.removeItemDecoration(mEndOffsetItemDecoration);
@@ -92,6 +110,16 @@ public class VerticalLinearLayoutManagerSampleActivity extends ActionBarActivity
         } else {
             mRecyclerView.addItemDecoration(mEndOffsetItemDecoration);
             mEndOffsetVisible = true;
+        }
+    }
+
+    private void toggleEndDrawableOffsetVisibility() {
+        if (mEndDrawableOffsetVisible) {
+            mRecyclerView.removeItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = false;
+        } else {
+            mRecyclerView.addItemDecoration(mEndDrawableOffsetItemDecoration);
+            mEndDrawableOffsetVisible = true;
         }
     }
 
@@ -107,8 +135,18 @@ public class VerticalLinearLayoutManagerSampleActivity extends ActionBarActivity
         }
 
         @Override
+        public void onStartDrawableOffsetVisibilityChange() {
+            toggleStartDrawableOffsetVisibility();
+        }
+
+        @Override
         public void onEndOffsetVisibilityChange() {
             toggleEndOffsetVisibility();
+        }
+
+        @Override
+        public void onEndDrawableOffsetVisibilityChange() {
+            toggleEndDrawableOffsetVisibility();
         }
     };
 }

--- a/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/view/DividerControlsView.java
+++ b/sample/src/main/java/com/dgreenhalgh/android/simpleitemdecorationsample/view/DividerControlsView.java
@@ -13,7 +13,9 @@ public class DividerControlsView extends LinearLayout {
 
     private CheckBox mDividersCheckBox;
     private CheckBox mStartOffsetCheckBox;
+    private CheckBox mStartDrawableOffsetCheckBox;
     private CheckBox mEndOffsetCheckBox;
+    private CheckBox mEndDrawableOffsetCheckBox;
 
     private OnVisibilityChangeListener mOnVisibilityChangeListener;
 
@@ -42,11 +44,27 @@ public class DividerControlsView extends LinearLayout {
             }
         });
 
+        mStartDrawableOffsetCheckBox = (CheckBox) findViewById(R.id.view_divider_controls_startDrawableOffsetCheckBox);
+        mStartDrawableOffsetCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                mOnVisibilityChangeListener.onStartDrawableOffsetVisibilityChange();
+            }
+        });
+
         mEndOffsetCheckBox = (CheckBox) findViewById(R.id.view_divider_controls_endOffsetCheckBox);
         mEndOffsetCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 mOnVisibilityChangeListener.onEndOffsetVisibilityChange();
+            }
+        });
+
+        mEndDrawableOffsetCheckBox = (CheckBox) findViewById(R.id.view_divider_controls_endDrawableOffsetCheckBox);
+        mEndDrawableOffsetCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                mOnVisibilityChangeListener.onEndDrawableOffsetVisibilityChange();
             }
         });
     }
@@ -58,6 +76,8 @@ public class DividerControlsView extends LinearLayout {
     public interface OnVisibilityChangeListener {
         void onDividerVisibilityChange();
         void onStartOffsetVisibilityChange();
+        void onStartDrawableOffsetVisibilityChange();
         void onEndOffsetVisibilityChange();
+        void onEndDrawableOffsetVisibilityChange();
     }
 }

--- a/sample/src/main/res/drawable/divider_sample.xml
+++ b/sample/src/main/res/drawable/divider_sample.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <size android:width="@dimen/divider_size"
         android:height="@dimen/divider_size"/>
-    <solid android:color="@android:color/holo_green_light"/>
+    <solid android:color="@android:color/transparent"/>
 </shape>

--- a/sample/src/main/res/drawable/divider_sample.xml
+++ b/sample/src/main/res/drawable/divider_sample.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <size android:width="@dimen/divider_size"
         android:height="@dimen/divider_size"/>
-    <solid android:color="@android:color/transparent"/>
+    <solid android:color="@android:color/holo_green_light"/>
 </shape>

--- a/sample/src/main/res/layout/view_divider_controls.xml
+++ b/sample/src/main/res/layout/view_divider_controls.xml
@@ -9,16 +9,41 @@
         android:layout_height="wrap_content"
         android:text="@string/view_divider_controls_dividerCheckBoxText"/>
 
-    <CheckBox
-        android:id="@+id/view_divider_controls_startOffsetCheckBox"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/view_divider_controls_startOffsetCheckBoxText"/>
+        android:orientation="horizontal">
 
-    <CheckBox
-        android:id="@+id/view_divider_controls_endOffsetCheckBox"
-        android:layout_width="wrap_content"
+        <CheckBox
+            android:id="@+id/view_divider_controls_startOffsetCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_divider_controls_startOffsetCheckBoxText"/>
+
+        <CheckBox
+            android:id="@+id/view_divider_controls_startDrawableOffsetCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_divider_controls_startDrawableOffsetCheckBoxText"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/view_divider_controls_endOffsetCheckBoxText"/>
+        android:orientation="horizontal">
 
+        <CheckBox
+            android:id="@+id/view_divider_controls_endOffsetCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_divider_controls_endOffsetCheckBoxText"/>
+
+        <CheckBox
+            android:id="@+id/view_divider_controls_endDrawableOffsetCheckBox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/view_divider_controls_endDrawableOffsetCheckBoxText"/>
+
+    </LinearLayout>
 </merge>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
     <!-- Sample Activities -->
     <string name="view_divider_controls_dividerCheckBoxText">Dividers</string>
     <string name="view_divider_controls_startOffsetCheckBoxText">Start offset</string>
+    <string name="view_divider_controls_startDrawableOffsetCheckBoxText">Start drawable offset</string>
     <string name="view_divider_controls_endOffsetCheckBoxText">End offset</string>
+    <string name="view_divider_controls_endDrawableOffsetCheckBoxText">End drawable offset</string>
 
 </resources>

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridBottomOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridBottomOffsetItemDecoration.java
@@ -1,6 +1,8 @@
 package com.dgreenhalgh.android.simpleitemdecoration.grid;
 
+import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -11,10 +13,11 @@ import android.view.View;
 public class GridBottomOffsetItemDecoration extends RecyclerView.ItemDecoration {
 
     private int mOffsetPx;
+    private Drawable mOffsetDrawable;
     private int mNumColumns;
 
     /**
-     * Sole constructor. Takes in the size of the offset to be added to the
+     * Constructor that takes in the size of the offset to be added to the
      * bottom of the RecyclerView.
      *
      * @param offsetPx The size of the offset to be added to the bottom of the
@@ -23,6 +26,19 @@ public class GridBottomOffsetItemDecoration extends RecyclerView.ItemDecoration 
      */
     public GridBottomOffsetItemDecoration(int offsetPx, int numColumns) {
         mOffsetPx = offsetPx;
+        mNumColumns = numColumns;
+    }
+
+    /**
+     * Constructor that takes in a {@link Drawable} to be drawn at the bottom
+     * of the RecyclerView.
+     *
+     * @param offsetDrawable The {@code Drawable} to be added to the bottom of
+     *                       the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
+     */
+    public GridBottomOffsetItemDecoration(Drawable offsetDrawable, int numColumns) {
+        mOffsetDrawable = offsetDrawable;
         mNumColumns = numColumns;
     }
 
@@ -39,15 +55,50 @@ public class GridBottomOffsetItemDecoration extends RecyclerView.ItemDecoration 
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
         super.getItemOffsets(outRect, view, parent, state);
 
-        int itemCount = state.getItemCount();
-        int numChildrenOnLastRow = itemCount % mNumColumns;
-        if (numChildrenOnLastRow == 0) {
-            numChildrenOnLastRow = mNumColumns;
+        int childCount = state.getItemCount();
+        int lastRowChildCount = getLastRowChildCount(childCount);
+
+        boolean childIsInBottomRow = parent.getChildAdapterPosition(view) >= childCount - lastRowChildCount;
+        if (childIsInBottomRow) {
+            if (mOffsetPx > 0) {
+                outRect.bottom = mOffsetPx;
+            } else {
+                outRect.bottom = mOffsetDrawable.getIntrinsicHeight();
+            }
+        }
+    }
+
+    @Override
+    public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        super.onDraw(c, parent, state);
+        if (mOffsetDrawable == null) {
+            return;
         }
 
-        boolean childIsInBottomRow = parent.getChildAdapterPosition(view) >= itemCount - numChildrenOnLastRow;
-        if (childIsInBottomRow) {
-            outRect.bottom = mOffsetPx;
+        int childCount = state.getItemCount();
+        int lastRowChildCount = getLastRowChildCount(childCount);
+
+        int parentLeft = parent.getPaddingLeft();
+        int parentRight = parent.getWidth() - parent.getPaddingRight();
+        int offsetDrawableTop = 0;
+        int offsetDrawableBottom = 0;
+
+        for (int i = childCount - lastRowChildCount; i < childCount; i++) {
+            View child = parent.getChildAt(i);
+            offsetDrawableTop = child.getBottom();
+            offsetDrawableBottom = offsetDrawableTop + mOffsetDrawable.getIntrinsicHeight();
         }
+
+        mOffsetDrawable.setBounds(parentLeft, offsetDrawableTop, parentRight, offsetDrawableBottom);
+        mOffsetDrawable.draw(c);
+    }
+
+    private int getLastRowChildCount(int itemCount) {
+        int lastRowChildCount = itemCount % mNumColumns;
+        if (lastRowChildCount == 0) {
+            lastRowChildCount = mNumColumns;
+        }
+
+        return lastRowChildCount;
     }
 }

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -42,6 +42,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
     public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
         drawHorizontalDividers(canvas, parent);
         drawVerticalDividers(canvas, parent);
+
     }
 
     /**
@@ -69,24 +70,34 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     /**
-     * Adds horizontal dividers to a RecyclerView with a GridLayoutManager or
-     * its subclass.
+     * Adds horizontal dividers to a RecyclerView with a GridLayoutManager or its
+     * subclass.
      *
      * @param canvas The {@link Canvas} onto which dividers will be drawn
      * @param parent The RecyclerView onto which dividers are being added
      */
     private void drawHorizontalDividers(Canvas canvas, RecyclerView parent) {
-        int parentTop = parent.getPaddingTop();
-        int parentBottom = parent.getHeight() - parent.getPaddingBottom();
+        int childCount = parent.getChildCount();
+        int rowCount = childCount / mNumColumns;
+        int lastRowChildCount = childCount % mNumColumns;
 
-        for (int i = 0; i < mNumColumns; i++) {
-            View child = parent.getChildAt(i);
-            RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
+        for (int i = 1; i < mNumColumns; i++) {
+            int lastRowChildIndex;
+            if (i < lastRowChildCount) {
+                lastRowChildIndex = i + (rowCount * mNumColumns);
+            } else {
+                lastRowChildIndex = i + ((rowCount - 1) * mNumColumns);
+            }
 
-            int parentLeft = child.getRight() + params.rightMargin;
-            int parentRight = parentLeft + mHorizontalDivider.getIntrinsicWidth();
+            View firstRowChild = parent.getChildAt(i);
+            View lastRowChild = parent.getChildAt(lastRowChildIndex);
 
-            mHorizontalDivider.setBounds(parentLeft, parentTop, parentRight, parentBottom);
+            int dividerTop = firstRowChild.getTop();
+            int dividerRight = firstRowChild.getLeft();
+            int dividerLeft = dividerRight - mHorizontalDivider.getIntrinsicWidth();
+            int dividerBottom = lastRowChild.getBottom();
+
+            mHorizontalDivider.setBounds(dividerLeft, dividerTop, dividerRight, dividerBottom);
             mHorizontalDivider.draw(canvas);
         }
     }
@@ -99,23 +110,25 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      * @param parent The RecyclerView onto which dividers are being added
      */
     private void drawVerticalDividers(Canvas canvas, RecyclerView parent) {
-        int parentLeft = parent.getPaddingLeft();
-        int parentRight = parent.getWidth() - parent.getPaddingRight();
-
         int childCount = parent.getChildCount();
-        int numChildrenOnLastRow = childCount % mNumColumns;
-        int numRows = childCount / mNumColumns;
-        if (numChildrenOnLastRow == 0) { // TODO: Replace this with math
-            numRows--;
-        }
-        for (int i = 0; i < numRows; i++) {
-            View child = parent.getChildAt(i * mNumColumns);
-            RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
+        int rowCount = childCount / mNumColumns;
+        int rightmostChildIndex;
+        for (int i = 1; i <= rowCount; i++) {
+            if (i == rowCount) {
+                rightmostChildIndex = parent.getChildCount() - 1;
+            } else {
+                rightmostChildIndex = (i * mNumColumns) + mNumColumns - 1;
+            }
 
-            int parentTop = child.getBottom() + params.bottomMargin;
-            int parentBottom = parentTop + mVerticalDivider.getIntrinsicHeight();
+            View leftmostChild = parent.getChildAt(i * mNumColumns);
+            View rightmostChild = parent.getChildAt(rightmostChildIndex);
 
-            mVerticalDivider.setBounds(parentLeft, parentTop, parentRight, parentBottom);
+            int dividerLeft = leftmostChild.getLeft();
+            int dividerBottom = leftmostChild.getTop();
+            int dividerTop = dividerBottom - mVerticalDivider.getIntrinsicHeight();
+            int dividerRight = rightmostChild.getRight();
+
+            mVerticalDivider.setBounds(dividerLeft, dividerTop, dividerRight, dividerBottom);
             mVerticalDivider.draw(canvas);
         }
     }

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridTopOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridTopOffsetItemDecoration.java
@@ -1,6 +1,8 @@
 package com.dgreenhalgh.android.simpleitemdecoration.grid;
 
+import android.graphics.Canvas;
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -11,10 +13,11 @@ import android.view.View;
 public class GridTopOffsetItemDecoration extends RecyclerView.ItemDecoration {
 
     private int mOffsetPx;
+    private Drawable mOffsetDrawable;
     private int mNumColumns;
 
     /**
-     * Sole constructor. Takes in the size of the offset to be added to the top
+     * Constructor that takes in the size of the offset to be added to the top
      * of the RecyclerView.
      *
      * @param offsetPx The size of the offset to be added to the top of the
@@ -23,6 +26,19 @@ public class GridTopOffsetItemDecoration extends RecyclerView.ItemDecoration {
      */
     public GridTopOffsetItemDecoration(int offsetPx, int numColumns) {
         mOffsetPx = offsetPx;
+        mNumColumns = numColumns;
+    }
+
+    /**
+     * Constructor that takes in a {@link Drawable} to be drawn at the top of
+     * the RecyclerView.
+     *
+     * @param offsetDrawable The {@code Drawable} to be added to the top of the
+     *                       RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
+     */
+    public GridTopOffsetItemDecoration(Drawable offsetDrawable, int numColumns) {
+        mOffsetDrawable = offsetDrawable;
         mNumColumns = numColumns;
     }
 
@@ -41,7 +57,27 @@ public class GridTopOffsetItemDecoration extends RecyclerView.ItemDecoration {
 
         boolean childIsInTopRow = parent.getChildAdapterPosition(view) < mNumColumns;
         if (childIsInTopRow) {
-            outRect.top = mOffsetPx;
+            if (mOffsetPx > 0) {
+                outRect.top = mOffsetPx;
+            } else if (mOffsetDrawable != null) {
+                outRect.top = mOffsetDrawable.getIntrinsicHeight();
+            }
         }
+    }
+
+    @Override
+    public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
+        super.onDraw(c, parent, state);
+        if (mOffsetDrawable == null) {
+            return;
+        }
+
+        int parentLeft = parent.getPaddingLeft();
+        int parentRight = parent.getWidth() - parent.getPaddingRight();
+        int parentTop = parent.getPaddingTop();
+        int offsetDrawableBottom = parentTop + mOffsetDrawable.getIntrinsicHeight();
+
+        mOffsetDrawable.setBounds(parentLeft, parentTop, parentRight, offsetDrawableBottom);
+        mOffsetDrawable.draw(c);
     }
 }


### PR DESCRIPTION
Depends on #17.

Before this PR, we relied on the bounds of the parent `RecyclerView` to determine the layout bounds of our dividers. This is an issue in `GridLayoutManager`-based `RecyclerView`s as dividers extended past the last child in the scroll direction to the end of the RecyclerView.

I've changed the behavior of `GridDividerItemDecoration` to layout dividers based off of the first and last child in the RecyclerView in a given direction.
