### PR TITLE
Add alternative constructors which take resource IDs

### DIFF
--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridBottomOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridBottomOffsetItemDecoration.java
@@ -43,6 +43,21 @@ public class GridBottomOffsetItemDecoration extends RecyclerView.ItemDecoration 
     }
 
     /**
+     * Constructor that takes in a drawable resource ID referencing a {@link Drawable}
+     * to be drawn at the bottom of the RecyclerView.
+     *
+     * @param context A context
+     * @param offsetDrawableResId A resource ID referencing the {@code Drawable}
+     *                            to be added to the bottom of the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
+     */
+    public GridBottomOffsetItemDecoration(Context context, @DrawableRes int offsetDrawableResId,
+                                          int numColumns) {
+        mOffsetDrawable = ContextCompat.getDrawable(context, offsetDrawableResId);
+        mNumColumns = numColumns;
+    }
+
+    /**
      * Determines the size and the location of the offset to be added to the
      * bottom of the RecyclerView.
      *

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -16,7 +16,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
     private int mNumColumns;
 
     /**
-     * Sole constructor. Takes in {@link Drawable} objects to be used as
+     * Constructor that takes in {@link Drawable} objects to be used as
      * horizontal and vertical dividers.
      *
      * @param horizontalDivider A divider {@code Drawable} to be drawn on the
@@ -28,6 +28,24 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
     public GridDividerItemDecoration(Drawable horizontalDivider, Drawable verticalDivider, int numColumns) {
         mHorizontalDivider = horizontalDivider;
         mVerticalDivider = verticalDivider;
+        mNumColumns = numColumns;
+    }
+
+    /**
+     * Constructor that takes in drawable resource IDs referencing {@link Drawable}
+     * objects to be drawn at the bottom of the RecyclerView.
+     *
+     * @param context A context
+     * @param horizontalDividerResId A resource ID referencing a divider {@code Drawable}
+     *                               to be drawn on the rows of the grid of the RecyclerView
+     * @param verticalDividerResId A resource ID referencing a divider {@code Drawable}
+     *                             to be drawn on the columns of the grid of the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
+     */
+    public GridDividerItemDecoration(Context context, @DrawableRes int horizontalDividerResId,
+                                     @DrawableRes int verticalDividerResId, int numColumns) {
+        mHorizontalDivider = ContextCompat.getDrawable(context, horizontalDividerResId);
+        mVerticalDivider = ContextCompat.getDrawable(context, verticalDividerResId);
         mNumColumns = numColumns;
     }
 

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridTopOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridTopOffsetItemDecoration.java
@@ -43,6 +43,21 @@ public class GridTopOffsetItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     /**
+     * Constructor that takes in a drawable resource ID referencing a {@link Drawable}
+     * to be drawn at the top of the RecyclerView.
+     *
+     * @param context A context
+     * @param offsetDrawableResId A resource ID referencing the {@code Drawable}
+     *                            to be added to the top of the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
+     */
+    public GridTopOffsetItemDecoration(Context context, @DrawableRes int offsetDrawableResId,
+                                       int numColumns) {
+        mOffsetDrawable = ContextCompat.getDrawable(context, offsetDrawableResId);
+        mNumColumns = numColumns;
+    }
+
+    /**
      * Determines the size and the location of the offset to be added to the
      * top of the RecyclerView.
      *

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/DividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/DividerItemDecoration.java
@@ -17,13 +17,25 @@ public class DividerItemDecoration extends RecyclerView.ItemDecoration {
     private int mOrientation;
 
     /**
-     * Sole constructor. Takes in a {@link Drawable} to be used as the interior
+     * Constructor that takes in a {@link Drawable} to be used as the interior
      * divider.
      *
      * @param divider A divider {@code Drawable} to be drawn on the RecyclerView
      */
     public DividerItemDecoration(Drawable divider) {
         mDivider = divider;
+    }
+
+    /**
+     * Constructor that takes in a drawable resource ID referencing a {@link Drawable}
+     * to be used as the interior divider.
+     *
+     * @param context A context
+     * @param dividerResId A resource ID referencing a divider {@code Drawable}
+     *                     to be drawn on the RecyclerView
+     */
+    public DividerItemDecoration(Context context, @DrawableRes int dividerResId) {
+        mDivider = ContextCompat.getDrawable(context, dividerResId);
     }
 
     /**

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/EndOffsetItemDecoration.java
@@ -44,6 +44,18 @@ public class EndOffsetItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     /**
+     * Constructor that takes in a drawable resource ID referencing a {@link Drawable}
+     * to be drawn at the end of the RecyclerView.
+     *
+     * @param context A context
+     * @param offsetDrawableResId A resource ID referencing a {@code Drawable} to be
+     *                            added to the end of the RecyclerView
+     */
+    public EndOffsetItemDecoration(Context context, @DrawableRes int offsetDrawableResId) {
+        mOffsetDrawable = ContextCompat.getDrawable(context, offsetDrawableResId);
+    }
+
+    /**
      * Determines the size and location of the offset to be added to the end
      * of the RecyclerView.
      *

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/linear/StartOffsetItemDecoration.java
@@ -44,6 +44,18 @@ public class StartOffsetItemDecoration extends RecyclerView.ItemDecoration {
     }
 
     /**
+     * Constructor that takes in a drawable resource ID referencing a {@link Drawable}
+     * to be drawn at the start of the RecyclerView.
+     *
+     * @param context A context
+     * @param offsetDrawableResId A resource ID referencing a {@code Drawable} to be
+     *                            added to the start of the RecyclerView
+     */
+    public StartOffsetItemDecoration(Context context, @DrawableRes int offsetDrawableResId) {
+        mOffsetDrawable = ContextCompat.getDrawable(context, offsetDrawableResId);
+    }
+
+    /**
      * Determines the size and location of the offset to be added to the start
      * of the RecyclerView.
      *


### PR DESCRIPTION
Adds alternative constructors to all Decoration classes which take resource IDs referencing `Drawable` objects rather than Drawable objects themselves. The constructor retrieves the referenced `Drawable` using `ContextCompat` and assigns it to the appropriate field. This affords the developer implementing this library additional freedom and flexibility.
