### PR TITLE
Fix 31 - GridDividerItemDecoration crashes on drawVerticalDividers(...)

### DIFF
--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -21,9 +21,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param horizontalDivider A divider {@code Drawable} to be drawn on the
      *                          rows of the grid of the RecyclerView
-     * @param verticalDivider   A divider {@code Drawable} to be drawn on the
-     *                          columns of the grid of the RecyclerView
-     * @param numColumns        The number of columns in the grid of the RecyclerView
+     * @param verticalDivider A divider {@code Drawable} to be drawn on the
+     *                        columns of the grid of the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
      */
     public GridDividerItemDecoration(Drawable horizontalDivider, Drawable verticalDivider, int numColumns) {
         mHorizontalDivider = horizontalDivider;
@@ -36,7 +36,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param canvas The {@link Canvas} onto which dividers will be drawn
      * @param parent The RecyclerView onto which dividers are being added
-     * @param state  The current RecyclerView.State of the RecyclerView
+     * @param state The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
@@ -50,9 +50,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      * RecyclerView.
      *
      * @param outRect The {@link Rect} of offsets to be added around the child view
-     * @param view    The child view to be decorated with an offset
-     * @param parent  The RecyclerView onto which dividers are being added
-     * @param state   The current RecyclerView.State of the RecyclerView
+     * @param view The child view to be decorated with an offset
+     * @param parent The RecyclerView onto which dividers are being added
+     * @param state The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -21,9 +21,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param horizontalDivider A divider {@code Drawable} to be drawn on the
      *                          rows of the grid of the RecyclerView
-     * @param verticalDivider A divider {@code Drawable} to be drawn on the
-     *                        columns of the grid of the RecyclerView
-     * @param numColumns The number of columns in the grid of the RecyclerView
+     * @param verticalDivider   A divider {@code Drawable} to be drawn on the
+     *                          columns of the grid of the RecyclerView
+     * @param numColumns        The number of columns in the grid of the RecyclerView
      */
     public GridDividerItemDecoration(Drawable horizontalDivider, Drawable verticalDivider, int numColumns) {
         mHorizontalDivider = horizontalDivider;
@@ -36,7 +36,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param canvas The {@link Canvas} onto which dividers will be drawn
      * @param parent The RecyclerView onto which dividers are being added
-     * @param state The current RecyclerView.State of the RecyclerView
+     * @param state  The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
@@ -50,9 +50,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      * RecyclerView.
      *
      * @param outRect The {@link Rect} of offsets to be added around the child view
-     * @param view The child view to be decorated with an offset
-     * @param parent The RecyclerView onto which dividers are being added
-     * @param state The current RecyclerView.State of the RecyclerView
+     * @param view    The child view to be decorated with an offset
+     * @param parent  The RecyclerView onto which dividers are being added
+     * @param state   The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
@@ -111,7 +111,13 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      */
     private void drawVerticalDividers(Canvas canvas, RecyclerView parent) {
         int childCount = parent.getChildCount();
+
+        // number of full rows
         int rowCount = childCount / mNumColumns;
+        if ((childCount % mNumColumns) == 0) {
+            rowCount--;
+        }
+
         int rightmostChildIndex;
         for (int i = 1; i <= rowCount; i++) {
             if (i == rowCount) {


### PR DESCRIPTION
Fixes https://github.com/bignerdranch/simple-item-decoration/issues/31

A recent change to the vertical divider logic removed the check for `numChildrenOnLastRow`. That caused a crash when the last row was full. I find this version of the calculation simpler than the old version and I think it fits better with the new logic of the method.

------------------------

I hope you do not mind adding the comment there - I spent quite a long time trying to figure out the purpose of some of the variables and I hope this comment helps future maintainers.

As with all contributions to foreign repos, I'm happy to change the styling to be consistent with your team so let me know what I should change.