### PR TITLE
Fix 33 - GridDividerItemDecoration crashes on an empty list

### DIFF
--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -21,9 +21,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param horizontalDivider A divider {@code Drawable} to be drawn on the
      *                          rows of the grid of the RecyclerView
-     * @param verticalDivider   A divider {@code Drawable} to be drawn on the
-     *                          columns of the grid of the RecyclerView
-     * @param numColumns        The number of columns in the grid of the RecyclerView
+     * @param verticalDivider A divider {@code Drawable} to be drawn on the
+     *                        columns of the grid of the RecyclerView
+     * @param numColumns The number of columns in the grid of the RecyclerView
      */
     public GridDividerItemDecoration(Drawable horizontalDivider, Drawable verticalDivider, int numColumns) {
         mHorizontalDivider = horizontalDivider;
@@ -36,7 +36,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param canvas The {@link Canvas} onto which dividers will be drawn
      * @param parent The RecyclerView onto which dividers are being added
-     * @param state  The current RecyclerView.State of the RecyclerView
+     * @param state The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
@@ -50,9 +50,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      * RecyclerView.
      *
      * @param outRect The {@link Rect} of offsets to be added around the child view
-     * @param view    The child view to be decorated with an offset
-     * @param parent  The RecyclerView onto which dividers are being added
-     * @param state   The current RecyclerView.State of the RecyclerView
+     * @param view The child view to be decorated with an offset
+     * @param parent The RecyclerView onto which dividers are being added
+     * @param state The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {

--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -21,9 +21,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param horizontalDivider A divider {@code Drawable} to be drawn on the
      *                          rows of the grid of the RecyclerView
-     * @param verticalDivider A divider {@code Drawable} to be drawn on the
-     *                        columns of the grid of the RecyclerView
-     * @param numColumns The number of columns in the grid of the RecyclerView
+     * @param verticalDivider   A divider {@code Drawable} to be drawn on the
+     *                          columns of the grid of the RecyclerView
+     * @param numColumns        The number of columns in the grid of the RecyclerView
      */
     public GridDividerItemDecoration(Drawable horizontalDivider, Drawable verticalDivider, int numColumns) {
         mHorizontalDivider = horizontalDivider;
@@ -36,7 +36,7 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      *
      * @param canvas The {@link Canvas} onto which dividers will be drawn
      * @param parent The RecyclerView onto which dividers are being added
-     * @param state The current RecyclerView.State of the RecyclerView
+     * @param state  The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void onDraw(Canvas canvas, RecyclerView parent, RecyclerView.State state) {
@@ -50,9 +50,9 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
      * RecyclerView.
      *
      * @param outRect The {@link Rect} of offsets to be added around the child view
-     * @param view The child view to be decorated with an offset
-     * @param parent The RecyclerView onto which dividers are being added
-     * @param state The current RecyclerView.State of the RecyclerView
+     * @param view    The child view to be decorated with an offset
+     * @param parent  The RecyclerView onto which dividers are being added
+     * @param state   The current RecyclerView.State of the RecyclerView
      */
     @Override
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
@@ -92,13 +92,16 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
             View firstRowChild = parent.getChildAt(i);
             View lastRowChild = parent.getChildAt(lastRowChildIndex);
 
-            int dividerTop = firstRowChild.getTop();
-            int dividerRight = firstRowChild.getLeft();
-            int dividerLeft = dividerRight - mHorizontalDivider.getIntrinsicWidth();
-            int dividerBottom = lastRowChild.getBottom();
+            // handle case where first row is not full
+            if (firstRowChild != null) {
+                int dividerTop = firstRowChild.getTop();
+                int dividerRight = firstRowChild.getLeft();
+                int dividerLeft = dividerRight - mHorizontalDivider.getIntrinsicWidth();
+                int dividerBottom = lastRowChild.getBottom();
 
-            mHorizontalDivider.setBounds(dividerLeft, dividerTop, dividerRight, dividerBottom);
-            mHorizontalDivider.draw(canvas);
+                mHorizontalDivider.setBounds(dividerLeft, dividerTop, dividerRight, dividerBottom);
+                mHorizontalDivider.draw(canvas);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #33 

When the first row of the grid is not fully populated, `firstRowChild` ends up being null. This is the simplest fix.

Another way may be to change the row calculation logic as in PR #35 .

------------------------

I hope you do not mind adding the comment there - I spent quite a long time trying to figure out the purpose of some of the variables and I hope this comment helps future maintainers.

As with all contributions to foreign repos, I'm happy to change the styling to be consistent with your team so let me know what I should change.