### PR TITLE
Fix 34 - GridDividerItemDecoration item offsets do not space columns correctly

### DIFF
--- a/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
+++ b/simpleitemdecoration/src/main/java/com/dgreenhalgh/android/simpleitemdecoration/grid/GridDividerItemDecoration.java
@@ -58,12 +58,19 @@ public class GridDividerItemDecoration extends RecyclerView.ItemDecoration {
     public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
         super.getItemOffsets(outRect, view, parent, state);
 
-        boolean childIsInLeftmostColumn = (parent.getChildAdapterPosition(view) % mNumColumns) == 0;
-        if (!childIsInLeftmostColumn) {
-            outRect.left = mHorizontalDivider.getIntrinsicWidth();
+        int childAdapterPosition = parent.getChildAdapterPosition(view);
+
+        // proportion the offsets correctly given a fixed width
+        if (mNumColumns > 1) {
+            int columnPosition = childAdapterPosition % mNumColumns;
+            int nudge = Math.round((float) mHorizontalDivider.getIntrinsicWidth() / mNumColumns);
+
+            outRect.left = columnPosition * nudge;
+            outRect.right = (mNumColumns - columnPosition - 1) * nudge;
         }
 
-        boolean childIsInFirstRow = (parent.getChildAdapterPosition(view)) < mNumColumns;
+        // vertical offset is constant
+        boolean childIsInFirstRow = childAdapterPosition < mNumColumns;
         if (!childIsInFirstRow) {
             outRect.top = mVerticalDivider.getIntrinsicHeight();
         }


### PR DESCRIPTION
Fixes #34 

The current library only supports vertical orientation which means that we can expand the grid vertically if required. So vertical offset calculation is simple, merely moving items down.

The current horizontal spacing method does the same as the vertical method, and ends up pushing items off the grid to the right (this is easiest seen with a wide divider, say `32dp`). This is because there is only a fixed horizontal width available that needs to contain the items and the dividers.

This PR calculates the amount of offset for each column to make sure that they are all evenly spaced across the width of the grid.

------------------------

I hope you do not mind adding the comment there - I spent quite a long time trying to figure out the purpose of some of the variables and I hope this comment helps future maintainers.

As with all contributions to foreign repos, I'm happy to change the styling to be consistent with your team so let me know what I should change.